### PR TITLE
fix(use-mutative): handle passing or returning new arrays to setter

### DIFF
--- a/libs/use-mutative/src/lib/use-mutative-reducer.tsx
+++ b/libs/use-mutative/src/lib/use-mutative-reducer.tsx
@@ -129,7 +129,7 @@ export function useMutativeReducer<
                 replaceResult !== result
               ) {
                 // TODO: do a clone when draft
-                replaceResult = { ...result };
+                replaceResult = Array.isArray(result) ? [...result] : { ...result };
               }
             });
 

--- a/libs/use-mutative/src/lib/use-mutative.spec.tsx
+++ b/libs/use-mutative/src/lib/use-mutative.spec.tsx
@@ -25,6 +25,44 @@ describe('useMutative', () => {
     expect(state2).toEqual({ items: [1, 2] });
   });
 
+  it('[useMutative] array state with callback return', () => {
+    const source: Readonly<number[]> = [1];
+
+    const { result } = renderHook(() => useMutative(source));
+
+    expect(result.current).toHaveLength(2);
+
+    const [state, setState] = result.current;
+    expect(state).toEqual([1]);
+    expect(typeof setState).toBe('function');
+
+    act(() =>
+      setState(() => ([1, 2]))
+    );
+
+    const [state2] = result.current;
+    expect(state2).toEqual([1, 2]);
+  });
+
+  it('[useMutative] array state with new value', () => {
+    const source: Readonly<number[]> = [1];
+
+    const { result } = renderHook(() => useMutative(source));
+
+    expect(result.current).toHaveLength(2);
+
+    const [state, setState] = result.current;
+    expect(state).toEqual([1]);
+    expect(typeof setState).toBe('function');
+
+    act(() =>
+      setState([1, 2])
+    );
+
+    const [state2] = result.current;
+    expect(state2).toEqual([1, 2]);
+  });
+
   it('[useMutative] with initializer', () => {
     const { result } = renderHook(() =>
       useMutative(() => ({


### PR DESCRIPTION
Hi! 👋 

when trying out `use-mutative` I noticed that setting or returning a new array to the `setState()` function will cause the resulting state to be an `Object` with integer keys instead of being a real `Array`. This causes problems when trying to use any of the array prototype methods on that state object.

Before (which appears to be a bug 🐛):

```js
const [state, setState] = useMutative(["a"]);
setState(["a", "b"]); // state becomes { 0: "a", 1: "b" }
```

With this PR:
```js
const [state, setState] = useMutative(["a"]);
setState(["a", "b"]); // state becomes ["a", "b"]
```

Please let me know if there's anything else I should test or update. I'm new to using this project :) Thank you!