### PR TITLE
fix(hook): sequential updater calls operate on latest state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,13 +81,12 @@ function useMutative<
     return options?.enablePatches ? [initialState, [], []] : initialState;
   });
   const updateState = useCallback((updater: any) => {
-    const currentState = options?.enablePatches ? state[0] : state;
-    if (typeof updater === 'function') {
-      setState(create(currentState, updater, options));
-    } else {
-      setState(create(currentState, () => updater, options));
-    }
-  }, [state]);
+    setState((latest: any) => {
+      const currentState = options?.enablePatches ? latest[0] : latest;
+      const updaterFn = typeof updater === 'function' ? updater : () => updater;
+      return create(currentState, updaterFn, options);
+    });
+  }, []);
   return (
     options?.enablePatches
       ? [state[0], updateState, state[1], state[2]]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -80,6 +80,27 @@ describe('useMutative', () => {
     expect(state2).toEqual({ items: [1, 2] });
   });
 
+  it('[useMutative] with multiple updates', () => {
+    const { result } = renderHook(() =>
+      useMutative({
+        items: [1],
+      })
+    );
+
+    const [state, setState] = result.current;
+    act(() => {
+      setState((draft) => {
+        draft.items.push(2);
+      });
+
+      setState((draft) => {
+        draft.items.push(3);
+      });
+    });
+    const [nextState] = result.current;
+    expect(nextState).toEqual({ items: [1, 2, 3] });
+  });
+
   it('[useMutative] with patches', () => {
     const { result } = renderHook(() =>
       useMutative(


### PR DESCRIPTION
## Description

Hola! I found what I think is a 🐛 bug where multiple `setState()` calls from `useMutative()` both operate on the initial state, which can lead to unexpected dropped data. Here's a somewhat forced example:

```ts
const [state, setState] = useMutative({
  items: [1],
});

function someHandler() {
  setState((draft) => {
    draft.items.push(2);
  });

  setState((draft) => {
    // `draft.items` doesn't include the 2
    // that was pushed above :(
    draft.items.push(3);
  });
}
```

Once the next render happens, `state.items` would be `[1, 3]` (only the last call is applied), instead of the cumulative `[1, 2, 3]`.

## A fix

This PR changes how the hook's `updateState()` function is defined so that it uses the [callback form of React `setState`](https://react.dev/reference/react/Component#setstate-parameters) so that each invocation of `useMutative` operates on the latest/up-to-date draft. Added a new test to verify the behavior :)

This also has a nice side-effect of making the `updateState()` callback identity stable, so it doesn't change between renders (although maybe it should when `options` changes?).